### PR TITLE
Throw

### DIFF
--- a/src/zpar.lib.cpp
+++ b/src/zpar.lib.cpp
@@ -9,8 +9,6 @@
 
 #define SIMPLE_HASH
 
-#include <Python.h>
-
 #include "definitions.h"
 #include "options.h"
 #include "tagger.h"


### PR DESCRIPTION
If anything goes wrong in zpar, it throws an error message expecting it to be caught by the top-level application.     These need to be caught before returning to python, or the Python interpreter will crash.
