### PR TITLE
Improve logging

### DIFF
--- a/examples/zpar_example.py
+++ b/examples/zpar_example.py
@@ -6,7 +6,7 @@ from six import print_
 
 from zpar import ZPar
 
-if __name__ == '__main__':
+def main():
     # set up an argument parser
     parser = argparse.ArgumentParser(prog='zpar_example.py')
     parser.add_argument('--modeldir', dest='modeldir',
@@ -49,3 +49,6 @@ if __name__ == '__main__':
         # compute dependency parses for all sentences in "test_tokenized.txt"
         tokenized_test_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_tokenized.txt')
         depparser.dep_parse_file(tokenized_test_file, "test.dep")
+
+if __name__ == '__main__':
+    main()

--- a/zpar/DepParser.py
+++ b/zpar/DepParser.py
@@ -8,9 +8,6 @@ import ctypes as c
 import logging
 import os
 
-# set up the logging
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
-
 
 class DepParser(object):
     """The ZPar English Dependency Parser"""

--- a/zpar/Parser.py
+++ b/zpar/Parser.py
@@ -8,8 +8,6 @@ import ctypes as c
 import logging
 import os
 
-# set up the logging
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
 
 class Parser(object):
     """The ZPar English Constituency Parser"""

--- a/zpar/Tagger.py
+++ b/zpar/Tagger.py
@@ -7,9 +7,6 @@ import ctypes as c
 import logging
 import os
 
-# set up the logging
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.WARNING)
-
 
 class Tagger(object):
     """The ZPar English POS Tagger"""

--- a/zpar/__init__.py
+++ b/zpar/__init__.py
@@ -7,7 +7,6 @@
 import _ctypes
 import ctypes as c
 import os
-import sys
 
 from .Tagger import Tagger
 from .Parser import Parser


### PR DESCRIPTION
- No need to initialize `logging` inside the library since it can cause unnecessary traffic in downstream applications.